### PR TITLE
Support for latest 2016.1 version

### DIFF
--- a/WebIdeConfig/Manager.inc
+++ b/WebIdeConfig/Manager.inc
@@ -280,7 +280,7 @@ class Manager {
    *
    * @var integer
    */
-  protected static $webIdeVersionMax = 100;
+  protected static $webIdeVersionMax = FALSE;
 
   /**
    * Commandline exit code.
@@ -305,11 +305,11 @@ class Manager {
    */
   protected static $webIdeHomePatterns = array(
     // Win.
-    1 => '@\.WebIde\d{2,3}@',
+    1 => '@\.WebIde\d{2,3}|.PhpStorm\d{4}\.\d{1,3}@',
     // Mac.
-    2 => '@WebIde\d{2,3}@',
+    2 => '@WebIde\d{2,3}|PhpStorm\d{4}\.\d{1,3}@',
     // Linux.
-    3 => '@\.WebIde\d{2,3}@',
+    3 => '@\.WebIde\d{2,3}|.PhpStorm\d{4}\.\d{1,3}@',
   );
 
   /**
@@ -373,6 +373,7 @@ class Manager {
 
     $return = array();
     foreach ($webide_homes as $webide_home) {
+      echo $webide_home->name;
       if (
         ($version = self::getWebIdeVersionFromPath($webide_home->name))
         &&
@@ -389,6 +390,8 @@ class Manager {
           $return[] = $webide_home->name;
         }
       }
+
+      echo $version;
     }
     sort($return);
 
@@ -407,7 +410,7 @@ class Manager {
   protected static function getWebIdeVersionFromPath($path) {
     $matches = NULL;
 
-    return (preg_match('/\d+$/', $path, $matches)) ? (int) $matches[0] : 0;
+    return (preg_match('/\d+/', $path, $matches)) ? (int) $matches[0] : 0;
   }
 
   /**

--- a/WebIdeConfig/Manager.inc
+++ b/WebIdeConfig/Manager.inc
@@ -350,7 +350,9 @@ class Manager {
   }
 
   /**
-   * Find all WebIde## directory in user's home.
+   * Find all PhpStorm configuration directories in user's home.
+   *
+   * Needs to consider WebIde## (old) and PhpStorm####.# (new) formats.
    *
    * @return string[]
    *   Directories.
@@ -373,7 +375,6 @@ class Manager {
 
     $return = array();
     foreach ($webide_homes as $webide_home) {
-      echo $webide_home->name;
       if (
         ($version = self::getWebIdeVersionFromPath($webide_home->name))
         &&
@@ -390,8 +391,6 @@ class Manager {
           $return[] = $webide_home->name;
         }
       }
-
-      echo $version;
     }
     usort($return, array(__CLASS__, 'compareWebIdeHomes'));
 

--- a/WebIdeConfig/Manager.inc
+++ b/WebIdeConfig/Manager.inc
@@ -393,9 +393,29 @@ class Manager {
 
       echo $version;
     }
-    sort($return);
+    usort($return, array(__CLASS__, 'compareWebIdeHomes'));
 
     return $return;
+  }
+
+  /**
+   * @param string $a
+   * @param string $b
+   *
+   * @return int
+   */
+  protected static function compareWebIdeHomes($a, $b) {
+    $a = ltrim($a, '.');
+    $b = ltrim($b, '.');
+    if (strpos($a, 'WebIde') === 0 && strpos($b, 'WebIde') === FALSE) {
+      return -1;
+    }
+
+    if (strpos($b, 'WebIde') === 0 && strpos($a, 'WebIde') === FALSE) {
+      return 1;
+    }
+
+    return version_compare($a, $b);
   }
 
   /**


### PR DESCRIPTION
This fixes issue #14. I disabled the maximum version check (and changed version extraction to no pick the last integer from the dir name, but the first) because it would become basically a fairly arbitrary effort. Set it to 2020 to have it break in four years? 

If there's anything you'd like changed, let me know.
